### PR TITLE
Added setup.py, and updated the installation instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+dist/
+kurt.egg-info/

--- a/README.md
+++ b/README.md
@@ -21,6 +21,19 @@ If you're interested in technical details of how the format works: the code shou
 
 ## Installation
 
+### Option 1 (setup.py)
+
+Download (or git clone) the latest version of Kurt. From the kurt folder
+containing `setup.py` run:
+
+    python setup.py install
+
+This will automatically install kurt, and its dependencies
+[Construct](http://construct.wikispaces.com/) and
+[PyPNG](https://code.google.com/p/pypng/).
+
+### Option 2 (manual install)
+
 Download the latest version of Kurt and extract the `kurt` folder somewhere in your `sys.path` — or in the same directory as your code, if you prefer.
 
 You'll need the **latest version** of the awesome [**Construct**](http://construct.wikispaces.com/) library — used for defining the format. It currently appears to be available [here](http://pypi.python.org/pypi/construct). (I'm using Construct version 2.04).
@@ -60,29 +73,35 @@ You'll probably just want to use the provided `ScratchProjectFile` and `ScratchS
 
 You can import just these classes them using:
 
-    from kurt.files import *
+```python
+from kurt.files import *
+```
 
 Load a file (you'll find a preview file, `game.sb`, saved in the `tests` directory; but feel free to try it with any Scratch project file).
 
-	# Just pass in the absolute or relative path to the file:
-	project = ScratchProjectFile("tests/game.sb")
-	
-    # You can reload the file at any time with .load()
+```python
+# Just pass in the absolute or relative path to the file:
+project = ScratchProjectFile("tests/game.sb")
+
+# You can reload the file at any time with .load()
+```
 
 Inspect project:
 
-    project.info['author'] # u'blob8108'
-    project.stage # <ScratchStageMorph(Stage)>
-    
-    # List fields on object:
-    project.stage.fields.keys() # ['volume', 'hPan', 'sprites', 'lists', 'vars', 'obsoleteSavedState', 'color', 'media', 'sceneStates', 'bounds', 'submorphs', 'zoom', 'isClone', 'blocksBin', 'flags', 'objName', 'owner', 'tempoBPM', 'vPan', 'properties', 'costume']
+```python
+project.info['author'] # u'blob8108'
+project.stage # <ScratchStageMorph(Stage)>
 
-    # Access fields using dot notation:
-    project.stage.tempoBPM # 60
-    project.stage.sprites # OrderedCollection([<ScratchSpriteMorph(ScratchCat)>])
-    
-    cat = project.stage.sprites[0]
-    cat.name # u'ScratchCat'
+# List fields on object:
+project.stage.fields.keys() # ['volume', 'hPan', 'sprites', 'lists', 'vars', 'obsoleteSavedState', 'color', 'media', 'sceneStates', 'bounds', 'submorphs', 'zoom', 'isClone', 'blocksBin', 'flags', 'objName', 'owner', 'tempoBPM', 'vPan', 'properties', 'costume']
+
+# Access fields using dot notation:
+project.stage.tempoBPM # 60
+project.stage.sprites # OrderedCollection([<ScratchSpriteMorph(ScratchCat)>])
+
+cat = project.stage.sprites[0]
+cat.name # u'ScratchCat'
+```
 
 Most of the objects you're interested in, like `ScratchStageMorph` and `ScratchSpriteMorph`, inherit from `UserObject`. You can use `.fields.keys()` to see the available fields on one of these objects.
 
@@ -92,12 +111,16 @@ Inline objects, such as `int` and `bool`, are converted transparently to their P
 
 Make changes:
 
-    cat.vars # {u'vx': 0.0}
-    cat.vars['vx'] = 100
+```python
+cat.vars # {u'vx': 0.0}
+cat.vars['vx'] = 100
+```
 
 Save:
 
-    project.save()
+```python
+project.save()
+```
 
 Now re-open the project with Scratch!
 
@@ -156,12 +179,16 @@ You'll find a script for automatically exporting all the scripts in a project fi
 ### Images
 You can find costumes under a sprite's `costumes` property (similarly for stage `backgrounds`).
 
-    cat.costumes # [<ImageMedia(costume1)>, <ImageMedia(costume2)>]
-    image = cat.costumes[0]
+```python
+cat.costumes # [<ImageMedia(costume1)>, <ImageMedia(costume2)>]
+image = cat.costumes[0]
+```
 
 Save to an external file:
 
-    image.save("scratch_cat.png")
+```python
+image.save("scratch_cat.png")
+```
 
 There's a script under `util/export_images.py` for exporting all the costumes in a Scratch project to separate files, with a folder for each sprite. It automatically makes a folder with the name `<project name> files` to put the images in. Again, just pass it the path to your project.
 

--- a/kurt/__init__.py
+++ b/kurt/__init__.py
@@ -1,49 +1,52 @@
 #coding=utf8
 
 # Copyright © 2012 Tim Radvan
-# 
+#
 # This file is part of Kurt.
-# 
-# Kurt is free software: you can redistribute it and/or modify it under the 
-# terms of the GNU Lesser General Public License as published by the Free 
-# Software Foundation, either version 3 of the License, or (at your option) any 
+#
+# Kurt is free software: you can redistribute it and/or modify it under the
+# terms of the GNU Lesser General Public License as published by the Free
+# Software Foundation, either version 3 of the License, or (at your option) any
 # later version.
-# 
-# Kurt is distributed in the hope that it will be useful, but WITHOUT ANY 
-# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR 
-# A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more 
+#
+# Kurt is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
 # details.
-# 
-# You should have received a copy of the GNU Lesser General Public License along 
-# with Kurt. If not, see <http://www.gnu.org/licenses/>.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Kurt. If not, see <http://www.gnu.org/licenses/>.
 
 """Python library for reading/writing Scratch project (.sb) and sprite files.
 
 DEPENDENCIES:
-    construct - for defining the format. 
+    construct - for defining the format.
                 Homepage: http://construct.wikispaces.com/
                 ["construct" in the Python package index]
 
 USAGE:
-    You'll probably just want to use the provided ScratchProjectFile and 
-    ScratchSpriteFile classes. Pass them the path to the file and use their 
+    You'll probably just want to use the provided ScratchProjectFile and
+    ScratchSpriteFile classes. Pass them the path to the file and use their
     provided .save() methods. Access them using:
         from kurt.files import *
-    
-    Most of the objects you're interested in, like ScratchStageMorph and 
-    ScratchSpriteMorph, inherit from UserObject. You can use .fields.keys() 
+
+    Most of the objects you're interested in, like ScratchStageMorph and
+    ScratchSpriteMorph, inherit from UserObject. You can use .fields.keys()
     to see the available fields on one of these objects.
-    
-    FixedObjects have a .value property to access their value. Inline objects, 
-    such as int and bool, are converted to their Pythonic counterparts. Array 
+
+    FixedObjects have a .value property to access their value. Inline objects,
+    such as int and bool, are converted to their Pythonic counterparts. Array
     and Dictionary are converted to list and dict.
-    
-    Tested with Python 2.6. Works with Scratch 1.4; not tested with earlier versions, but probably works.
-    
-    Scratch is created by the Lifelong Kindergarten Group at the MIT Media Lab. 
+
+    Tested with Python 2.6. Works with Scratch 1.4; not tested with earlier
+    versions, but probably works.
+
+    Scratch is created by the Lifelong Kindergarten Group at the MIT Media Lab.
     See their website: http://scratch.mit.edu/
 """
 
 from kurt.objtable import *
 from kurt.files import *
 from kurt.scripts import *
+
+__version__ = '1.2.1'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import glob
+import re
+from setuptools import setup
+
+
+version = re.search("__version__ = '([^']+)'",
+                    open('kurt/__init__.py').read()).group(1)
+
+
+setup(name='kurt',
+      author='Tim Radvan',
+      author_email='blob8108@gmail.com',
+      description='A library for reading/writing MIT Scratch files.',
+      install_requires=['construct', 'pypng'],
+      keywords=['scratch'],
+      license='LGPL',
+      packages=['kurt'],
+      scripts=glob.glob('util/*'),
+      url='https://github.com/blob8108/kurt',
+      version=version
+)


### PR DESCRIPTION
setup.py requires a version, thus `__init__.py` now has a version number. This
should be updated appropriately.

Installation of `kurt` will install the util/*.py files into some `bin` folder
depending on the users setup. In my virtualenv the path is
<virtual_env_path>/bin.

The README was also updated to better pretty-print the python code blocks.

On a related note, it may be worthwhile to upload the project to pypi so that installation can be as simple as `easy_install kurt` or `pip install kurt`. With the setup.py file in place creating the project is trivial: `python setup.py register upload`. You will need an account of course.
