### PR TITLE
Added setup.py and updated installation notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 *.pyc
-construct/
-tests/* files/
-dist/
-kurt.egg-info/
 *.sb
+*.egg-info/
+build/
+construct/
+dist/
+files/
+tests/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,27 @@ If you're interested in technical details of how the format works: the code shou
 
 ## Installation
 
+Options 1 and 2 will automatically install kurt, and its dependencies
+[Construct](http://construct.wikispaces.com/) and
+[PyPNG](https://code.google.com/p/pypng/).
+
+### Option 1 (pip or easy_install)
+
+If you have either `easy_install` or `pip` installed, installation is as simple
+as running one of the following:
+
+    pip install kurt
+    easy_install kurt
+
+### Option 2 (setup.py)
+
+Download (or git clone) the latest version of Kurt. From the kurt folder
+containing `setup.py` run:
+
+    python setup.py install
+
+### Option 2 (manual install)
+
 Download the latest version of Kurt and extract the `kurt` folder somewhere in your `sys.path` — or in the same directory as your code, if you prefer.
 
 You'll need the **latest version** of the awesome [**Construct**](http://construct.wikispaces.com/) library — used for defining the format. It currently appears to be available [here](http://pypi.python.org/pypi/construct). (I'm using Construct version 2.04).

--- a/kurt/__init__.py
+++ b/kurt/__init__.py
@@ -49,3 +49,5 @@ from kurt.objtable import *
 from kurt.files import *
 from kurt.scripts import *
 from kurt.scratchblocks import parse_scratchblocks, ParseError
+
+__version__ = '1.2.2dev.bboe'

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,21 @@
+import glob
+import re
+from setuptools import setup
+
+
+version = re.search("__version__ = '([^']+)'",
+                    open('kurt/__init__.py').read()).group(1)
+
+
+setup(name='kurt',
+      author='Tim Radvan',
+      author_email='blob8108@gmail.com',
+      description='A library for reading/writing MIT Scratch files.',
+      install_requires=['construct', 'pypng'],
+      keywords=['scratch'],
+      license='LGPL',
+      packages=['kurt'],
+      scripts=glob.glob('util/*'),
+      url='https://github.com/blob8108/kurt',
+      version=version
+)

--- a/util/block_plugin.py
+++ b/util/block_plugin.py
@@ -29,10 +29,12 @@ outputs [scratchblocks] formatted code for Scratch forums/wiki.
 #
 # - Can't have empty dropdowns eg. broadcast [ v]
 
+import sys
+
 try:
     import kurt
 except ImportError: # try and find kurt directory
-    import os, sys
+    import os
     path_to_file = os.path.join(os.getcwd(), __file__)
     path_to_lib = os.path.split(os.path.split(path_to_file)[0])[0]
     sys.path.append(path_to_lib)


### PR DESCRIPTION
These changes are needed for using setuptools to install the package in development mode.

I have also registered kurt on pypi with this version of the code as I need it for easy dependency installation on a few projects I'm working on with undergraduates this summer. I'll be happy to hand control of the package over to you once these changes are incorporated into the main branch. I'm also happy to continue to manage the package on pypi if you'd prefer.

**Pypi Info**
http://pypi.python.org/pypi/kurt/1.2.2dev.bboe

Installation, along with dependency installation can now be accomplished via one of the following:

```
pip install kurt
easy_install kurt
```
