### PR TITLE
Include README.md in pypi packages and support wheel packages.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[wheel]
+universal = 1


### PR DESCRIPTION
The 2.0.5 release was broken because the README.md file is not included. Since I have access to the pypi repository, I removed that release, and released from this version (and I included a wheel distribution which is the new hotness).
